### PR TITLE
Fix URL match so it will only run on bandcamp

### DIFF
--- a/dist/dev.user.js
+++ b/dist/dev.user.js
@@ -10,8 +10,7 @@
 // @require         https://unpkg.com/react@18/umd/react.development.js
 // @require         https://unpkg.com/react-dom@18/umd/react-dom.development.js
 // @run-at          document-start
-// @match           https://*/*
-// @match           https://bandcamp.com/*
+// @match           https://*.bandcamp.com/*
 // @exclude         https://bandcamp.com/videoframe*
 // @exclude         https://bandcamp.com/EmbeddedPlayer*
 // @connect         bandcamp.com


### PR DESCRIPTION
Changed match attribute so it will only run on bandcamp and not every site the user visits. This will also suppport urls that bands make such as

https://foreignowl.bandcamp.com/album/the-nice-place
